### PR TITLE
✨ Suppress advancements if player is op

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "land.vani.plugin"
-version = "2.0.1"
+version = "2.0.2"
 
 repositories {
     mavenLocal()

--- a/src/main/kotlin/land/vani/plugin/core/di/Module.kt
+++ b/src/main/kotlin/land/vani/plugin/core/di/Module.kt
@@ -19,6 +19,7 @@ import land.vani.plugin.core.features.OpCommand
 import land.vani.plugin.core.features.PortalWarpNpc
 import land.vani.plugin.core.features.ResetWorld
 import land.vani.plugin.core.features.SafetyLogin
+import land.vani.plugin.core.features.SuppressAdvancementOp
 import land.vani.plugin.core.features.VanilandCommand
 import land.vani.plugin.core.features.Vote
 import land.vani.plugin.core.features.WorldWarpMobNpc
@@ -90,34 +91,36 @@ fun configModule() = module {
 
 fun featuresModule() = module {
     singleOf(::AutoMessage)
-    singleOf(::Newbie)
-    singleOf(::Vote)
-    singleOf(::SafetyLogin)
-    singleOf(::VanilandCommand)
-    singleOf(::OpCommand)
-    singleOf(::Commands)
-    singleOf(::PortalWarpNpc)
-    singleOf(::WorldWarpNpc)
-    singleOf(::WorldWarpMobNpc)
-    singleOf(::ResetWorld)
     singleOf(::AutoRestart)
+    singleOf(::Commands)
     singleOf(::EntityCount)
+    singleOf(::Newbie)
+    singleOf(::OpCommand)
+    singleOf(::PortalWarpNpc)
+    singleOf(::ResetWorld)
+    singleOf(::SafetyLogin)
+    singleOf(::SuppressAdvancementOp)
+    singleOf(::VanilandCommand)
+    singleOf(::Vote)
+    singleOf(::WorldWarpMobNpc)
+    singleOf(::WorldWarpNpc)
 
     single(named("features")) {
         mapOf(
             AutoMessage to lazy { get<AutoMessage>() },
-            Newbie to lazy { get<Newbie>() },
-            Vote to lazy { get<Vote>() },
-            SafetyLogin to lazy { get<SafetyLogin>() },
-            VanilandCommand to lazy { get<VanilandCommand>() },
-            OpCommand to lazy { get<OpCommand>() },
-            Commands to lazy { get<Commands>() },
-            PortalWarpNpc to lazy { get<PortalWarpNpc>() },
-            WorldWarpNpc to lazy { get<WorldWarpNpc>() },
-            WorldWarpMobNpc to lazy { get<WorldWarpMobNpc>() },
-            ResetWorld to lazy { get<ResetWorld>() },
             AutoRestart to lazy { get<AutoRestart>() },
-            EntityCount to lazy { get<EntityCount>() }
+            Commands to lazy { get<Commands>() },
+            EntityCount to lazy { get<EntityCount>() },
+            OpCommand to lazy { get<OpCommand>() },
+            Newbie to lazy { get<Newbie>() },
+            PortalWarpNpc to lazy { get<PortalWarpNpc>() },
+            ResetWorld to lazy { get<ResetWorld>() },
+            SafetyLogin to lazy { get<SafetyLogin>() },
+            SuppressAdvancementOp to lazy { get<SuppressAdvancementOp>() },
+            VanilandCommand to lazy { get<VanilandCommand>() },
+            Vote to lazy { get<Vote>() },
+            WorldWarpMobNpc to lazy { get<WorldWarpMobNpc>() },
+            WorldWarpNpc to lazy { get<WorldWarpNpc>() },
         )
     }
 }

--- a/src/main/kotlin/land/vani/plugin/core/features/SuppressAdvancementOp.kt
+++ b/src/main/kotlin/land/vani/plugin/core/features/SuppressAdvancementOp.kt
@@ -1,0 +1,23 @@
+package land.vani.plugin.core.features
+
+import com.destroystokyo.paper.event.player.PlayerAdvancementCriterionGrantEvent
+import land.vani.mcorouhlin.paper.event.cancelIf
+import land.vani.plugin.core.VanilandPlugin
+
+class SuppressAdvancementOp(
+    private val plugin: VanilandPlugin,
+) : Feature<SuppressAdvancementOp>() {
+    companion object : Key<SuppressAdvancementOp>("suppressAchievementsOp")
+
+    override val key: Key<SuppressAdvancementOp> = Companion
+
+    override suspend fun onEnable() {
+        registerListeners()
+    }
+
+    private fun registerListeners() = plugin.events {
+        cancelIf<PlayerAdvancementCriterionGrantEvent> { event ->
+            event.player.isOp
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,8 +1,15 @@
 features:
   autoMessage: true
-  newbie: true
-  safetyLogin: true
-  vanilandCommand: true
+  autoRestart: true
   commands: true
-  portalWarpNpc: true
   entityCount: true
+  newbie: true
+  opCommand: true
+  portalWarpNpc: true
+  resetWorld: true
+  safetyLogin: true
+  suppressAdvancementsOp: true
+  vanilandCommand: true
+  vote: true
+  worldWarpMobNpc: true
+  worldWarpNpc: true


### PR DESCRIPTION
OPを持っている状態で進捗の達成条件を進めることのないように変更。
例: OPを持った状態でスペクテイターで各地を飛び回っても「冒険の時間」は達成されない

進捗の達成メッセージ等で運営の存在を明かす不慮の事故を防ぐため。